### PR TITLE
Style updates

### DIFF
--- a/public/en/index.html
+++ b/public/en/index.html
@@ -15,9 +15,9 @@
     <title>EqualStreetNames Brussels</title>
 </head>
 
-<body class="d-flex flex-column">
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="#">EqualStreetNames.Brussels</a>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
+        <a class="navbar-brand" href="#">EqualStreetNames Brussels</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
@@ -66,7 +66,7 @@
                     <li class="gender-chart-label" data-gender="f">
                         <span class="fa-li"><i class="fas fa-lg fa-venus"></i></span>
                         Female:
-                        <span class="gender-chart-count"></span>
+                        <span class="gender-chart-count"></span></span>
                     </li>
                     <li class="gender-chart-label" data-gender="x">
                         <span class="fa-li"><i class="fas fa-lg fa-transgender-alt"></i></span>
@@ -76,7 +76,7 @@
                 </ul>
                 <canvas width="250" height="100"></canvas>
             </div>
-            <div id="count-information" class="text-muted small">
+            <div id="count-information" class="small">
                 There are <span id="count-person"></span> streetnames based on a person
                 on <span id="count-total"></span> streetnames.
             </div>

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -17,7 +17,7 @@
 
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
-        <a class="navbar-brand" href="#">EqualStreetNames Brussels</a>
+        <a class="navbar-brand" href="#">EqualStreetNames.Brussels</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -17,7 +17,7 @@
 
 <body class="d-flex flex-column">
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="#">EqualStreetNames Brussels</a>
+        <a class="navbar-brand" href="#">EqualStreetNames.Brussels</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -82,16 +82,10 @@
                 </ul>
                 <canvas width="250" height="100"></canvas>
             </div>
-            <<<<<<< HEAD <div id="count-information" class="small">
-                There are <span id="count-person"></span> streetnames based on a person
-                on <span id="count-total"></span> streetnames.
-                =======
-                <div id="count-information" class="text-muted small">
-                    <span id="count-person"></span> streetnames are based on a person
-                    on a total of <span id="count-total"></span> streetnames.
-                    >>>>>>> master
-                </div>
-        </div>
+            <div id="count-information" class="small">
+                Out of <span id="count-total"></span> streetnames, <span id="count-person"></span> are based on a
+                person.
+            </div>
     </main>
 
     <div id="about" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -228,7 +228,9 @@
                         have partnered up to organize 8 workshops to put together lists of name suggestions for the
                         municipalities. The names will be published in this section after each event and if their
                         profile doesn’t exist
-                        on Wikipedia, we will add it to the open platform!<br>
+                        on Wikipedia, we will add it to the open platform!
+                    </p>
+                    <p>
                         Workshops will take place once a month from March until December and will be organized each time
                         in a different municipality.
                         The first workshop will take place on <strong>23 March 2020</strong>

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -66,7 +66,7 @@
                     <li class="gender-chart-label" data-gender="f">
                         <span class="fa-li"><i class="fas fa-lg fa-venus"></i></span>
                         Female:
-                        <span class="gender-chart-count"></span></span>
+                        <span class="gender-chart-count"></span>
                     </li>
                     <li class="gender-chart-label" data-gender="x">
                         <span class="fa-li"><i class="fas fa-lg fa-transgender-alt"></i></span>

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -225,7 +225,7 @@
                     <p>
                         Each workshop will happen in a different municipality. If you are interested to host us or talk
                         to us about the workshops, please contact us via
-                        <a href="mailto:contact@openknowledge.be">contact@openknowledge.be</a>.
+                        <a href="mailto:equalstreetnames@openknowledge.be">equalstreetnames@openknowledge.be</a>.
                     </p>
                 </div>
             </div>
@@ -255,7 +255,7 @@
                         <ul>
                             <li>
                                 Open Knowledge Belgium:
-                                <a href="mailto:contact@openknowledge.be">contact@openknowledge.be</a>
+                                <a href="mailto:equalstreetnames@openknowledge.be">equalstreetnames@openknowledge.be</a>
                             </li>
                             <li>
                                 Noms Peut-Être:

--- a/resources/chart.ts
+++ b/resources/chart.ts
@@ -2,7 +2,7 @@
 
 import Chart from "chart.js";
 
-import colors from "./colors";
+import { global as colors } from "./colors";
 
 import statistics from "../static/statistics.json";
 

--- a/resources/colors.ts
+++ b/resources/colors.ts
@@ -4,12 +4,18 @@ interface StringMap {
   [key: string]: string;
 }
 
-const colors: StringMap = {
+const global: StringMap = {
   f: "#cc00ca", // female
-  fDesaturated: "#800080",
   m: "#C8C800", // male
   x: "#00a050", // transgender
   o: "#DDDDDD" // other (not a person)
 };
 
-export default colors;
+const popup: StringMap = {
+  f: "#800080",
+  m: global.m,
+  x: global.x,
+  o: global.o
+};
+
+export { global, popup };

--- a/resources/colors.ts
+++ b/resources/colors.ts
@@ -1,8 +1,8 @@
 "use strict";
 
 export default {
-  f: "#800080", // female
+  f: "#cc00ca", // female
   m: "#C8C800", // male
-  x: "#008040", // transgender
+  x: "#00a050", // transgender
   o: "#DDDDDD" // other (not a person)
 };

--- a/resources/colors.ts
+++ b/resources/colors.ts
@@ -6,6 +6,7 @@ interface StringMap {
 
 const colors: StringMap = {
   f: "#cc00ca", // female
+  fDesaturated: "#800080",
   m: "#C8C800", // male
   x: "#00a050", // transgender
   o: "#DDDDDD" // other (not a person)

--- a/resources/colors.ts
+++ b/resources/colors.ts
@@ -1,8 +1,14 @@
 "use strict";
 
-export default {
+interface StringMap {
+  [key: string]: string;
+}
+
+const colors: StringMap = {
   f: "#cc00ca", // female
   m: "#C8C800", // male
   x: "#00a050", // transgender
   o: "#DDDDDD" // other (not a person)
 };
+
+export default colors;

--- a/resources/map/events/click.ts
+++ b/resources/map/events/click.ts
@@ -2,6 +2,7 @@
 
 import mapboxgl, { Map, MapboxGeoJSONFeature, LngLat } from "mapbox-gl";
 
+import getGender from "../../wikidata/gender";
 import getName from "../../wikidata/labels";
 import getBirth from "../../wikidata/birth";
 import getDeath from "../../wikidata/death";
@@ -41,6 +42,7 @@ export default function(
     person !== null ? getBirth(person) : null,
     person !== null ? getDeath(person) : null,
     person !== null ? getDescription(person, lang) : null,
+    person !== null ? getGender(person) : null,
     person !== null ? getWikipedia(person, lang) : null
   );
 

--- a/resources/map/style/paint.ts
+++ b/resources/map/style/paint.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import colors from "../../colors";
+import { global as colors } from "../../colors";
 
 export default {
   "line-color": [

--- a/resources/popup.ts
+++ b/resources/popup.ts
@@ -1,5 +1,7 @@
 "use strict";
 
+import colors from "./colors";
+
 export default function(
   streetname: string,
   wikidata?: string | null,
@@ -7,18 +9,19 @@ export default function(
   birth?: number | null,
   death?: number | null,
   description?: string | null,
+  gender?: string | null,
   wikipedia?: { lang: string; url: string } | null
 ): string {
   let html = "";
-
   if (
     typeof wikidata !== "undefined" &&
     wikidata !== null &&
     // to-do: Find out why wikidata is a "null" string (instead of null)
     wikidata !== "null"
   ) {
+    const highlightColor = gender ? colors[gender.toLowerCase()] : "#fff";
     html += '<div class="popup-wikidata">';
-    html += `<div class="popup-name">${name}</div>`;
+    html += `<h2 class="popup-name highlight-low" style="background:linear-gradient(180deg, rgba(255, 255, 255, 0) 65%, ${highlightColor} 65%);">${name}</h2>`;
     if (birth !== null || death !== null) {
       html +=
         '<div class="popup-life">' +

--- a/resources/popup.ts
+++ b/resources/popup.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import colors from "./colors";
+import { popup as colors } from "./colors";
 
 export default function(
   streetname: string,
@@ -19,8 +19,7 @@ export default function(
     // to-do: Find out why wikidata is a "null" string (instead of null)
     wikidata !== "null"
   ) {
-    let highlightColor = gender ? colors[gender.toLowerCase()] : "#fff";
-    if (gender === "F") highlightColor = colors.fDesaturated;
+    const highlightColor = gender ? colors[gender.toLowerCase()] : "#fff";
     html += '<div class="popup-wikidata">';
     html += `
     <div class="popup-name">

--- a/resources/popup.ts
+++ b/resources/popup.ts
@@ -21,7 +21,11 @@ export default function(
   ) {
     const highlightColor = gender ? colors[gender.toLowerCase()] : "#fff";
     html += '<div class="popup-wikidata">';
-    html += `<h2 class="popup-name highlight-low" style="background:linear-gradient(180deg, rgba(255, 255, 255, 0) 65%, ${highlightColor} 65%);">${name}</h2>`;
+    html += `
+    <div class="popup-name">
+      <span class="popup-name__name">${name}</span>
+      <span class="highlight-low" style="background:linear-gradient(180deg, rgba(255, 255, 255, 0) 65%, ${highlightColor} 65%);"></span>
+    </div>`;
     if (birth !== null || death !== null) {
       html +=
         '<div class="popup-life">' +

--- a/resources/popup.ts
+++ b/resources/popup.ts
@@ -19,7 +19,8 @@ export default function(
     // to-do: Find out why wikidata is a "null" string (instead of null)
     wikidata !== "null"
   ) {
-    const highlightColor = gender ? colors[gender.toLowerCase()] : "#fff";
+    let highlightColor = gender ? colors[gender.toLowerCase()] : "#fff";
+    if (gender === "F") highlightColor = colors.fDesaturated;
     html += '<div class="popup-wikidata">';
     html += `
     <div class="popup-name">

--- a/resources/style.css
+++ b/resources/style.css
@@ -9,7 +9,6 @@ body {
 
 nav.navbar {
   background-color: rgba(52, 51, 50, 0.8);
-  position: fixed;
 }
 
 .nav-item {

--- a/resources/style.css
+++ b/resources/style.css
@@ -7,9 +7,22 @@ body {
   height: 100vh;
 }
 
+nav.navbar {
+  background-color: rgba(52, 51, 50, 0.8);
+  position: fixed;
+}
+
+.nav-item {
+  margin-left: 20px;
+}
+
+.navbar-nav {
+  color: #fff;
+}
+
 #map {
   background-color: #dddddd;
-  height: calc(100vh - 56px);
+  height: 100vh;
   width: 100%;
 }
 
@@ -27,8 +40,13 @@ body {
   margin-top: 10px;
 }
 
+.mapboxgl-ctrl-top-left,
+.mapboxgl-ctrl-top-right {
+  top: 60px;
+}
+
 #chart-overlay {
-  background-color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(52, 51, 50, 0.9);
   border-bottom-left-radius: 5px;
   border-top-left-radius: 5px;
   bottom: 50px;
@@ -36,4 +54,13 @@ body {
   position: absolute;
   right: 0;
   width: 250px;
+}
+
+#count-information {
+  margin-top: 10px;
+  color: #fff;
+}
+
+.navbar-dark .navbar-nav .nav-link {
+  color: rgba(255, 255, 255, 0.8) !important;
 }

--- a/resources/style.css
+++ b/resources/style.css
@@ -42,11 +42,14 @@ nav.navbar {
   padding: 6px;
 }
 .mapboxgl-popup-content > .popup-wikidata > .popup-name {
-  font-size: 1.3rem;
-  white-space: nowrap;
   margin-bottom: 6px;
-  font-family: "Trebuchet MS", Helvetica, sans-serif;
   display: inline-block;
+  position: relative;
+}
+.popup-name > .popup-name__name {
+  white-space: nowrap;
+  font-size: 1.3rem;
+  font-family: "Trebuchet MS", Helvetica, sans-serif;
 }
 .mapboxgl-popup-content > .popup-wikidata > .popup-links {
   margin-top: 10px;
@@ -75,6 +78,15 @@ nav.navbar {
 
 .navbar-dark .navbar-nav .nav-link {
   color: rgba(255, 255, 255, 0.8) !important;
+}
+
+.highlight-low {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  opacity: 0.5;
 }
 
 @keyframes fadein {

--- a/resources/style.css
+++ b/resources/style.css
@@ -29,12 +29,21 @@ nav.navbar {
 .mapboxgl-popup-content {
   min-width: 200px;
 }
+.mapboxgl-popup-content > hr {
+  margin: 0.5rem 0 0.5rem;
+}
 .mapboxgl-popup-content > .popup-streetname {
   font-weight: bold;
+}
+.mapboxgl-popup-content > .popup-wikidata {
+  font-size: 0.8rem;
+  padding: 6px;
 }
 .mapboxgl-popup-content > .popup-wikidata > .popup-name {
   font-size: 1.3rem;
   white-space: nowrap;
+  margin-bottom: 6px;
+  font-family: "Trebuchet MS", Helvetica, sans-serif;
 }
 .mapboxgl-popup-content > .popup-wikidata > .popup-links {
   margin-top: 10px;

--- a/resources/style.css
+++ b/resources/style.css
@@ -8,7 +8,7 @@ body {
 }
 
 nav.navbar {
-  background-color: rgba(52, 51, 50, 0.8);
+  background-color: rgba(52, 51, 50, 0.9);
 }
 
 .nav-item {

--- a/resources/style.css
+++ b/resources/style.css
@@ -26,6 +26,9 @@ nav.navbar {
   width: 100%;
 }
 
+.mapboxgl-popup {
+  animation: fadein 0.2s;
+}
 .mapboxgl-popup-content {
   min-width: 200px;
 }
@@ -44,6 +47,7 @@ nav.navbar {
   white-space: nowrap;
   margin-bottom: 6px;
   font-family: "Trebuchet MS", Helvetica, sans-serif;
+  display: inline-block;
 }
 .mapboxgl-popup-content > .popup-wikidata > .popup-links {
   margin-top: 10px;
@@ -72,4 +76,13 @@ nav.navbar {
 
 .navbar-dark .navbar-nav .nav-link {
   color: rgba(255, 255, 255, 0.8) !important;
+}
+
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }

--- a/resources/wikidata/gender.ts
+++ b/resources/wikidata/gender.ts
@@ -1,0 +1,9 @@
+"use strict";
+
+export default function(person: { gender?: string }): string | null {
+  if (typeof person.gender === "undefined") {
+    return null;
+  }
+
+  return person.gender;
+}


### PR DESCRIPTION
- Increased gender color saturation for black bg readability
- Header is now overlaying map, not a separate element
- EqualStreetNames.Brussels name
- Increased breatheability of popup boxes, but reduced vertical spacing between wikidata and street names
- Changed overlays to darker background and adjusted font colors
- Changed font of entity names in popup boxes
- Added slight popup fadein animation
- Added low highlight in popup based on wikidata gender
- Add a desaturated color for the female highlight to keep it purple