### PR TITLE
Update local installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ See [`docs/README.md`](./docs/README.md)
 ## Run locally
 
 ```
-git clone git@github.com:openknowledgebe/equalstreetnames.git
+git clone https://github.com/openknowledgebe/equalstreetnames.git
+cd equalstreetnames
 npm install
 npm run serve
 ```


### PR DESCRIPTION
I received an authentication error when trying to clone the repository using the instructions in the README, so I rewrote the instructions to use the https instead of git for the clone address, and added an instruction to change directory before running the npm commands.