### PR TITLE
Handle cases with bogus wikidata entry

### DIFF
--- a/scripts/wikidata.php
+++ b/scripts/wikidata.php
@@ -36,6 +36,9 @@ foreach ($tagged as $element) {
         $etymology = array_map('trim', $etymology);
 
         foreach ($etymology as $e) {
+            if (strpos($e, 'Q') !== 0) { // Skip if it doesn't start with Q
+                continue;
+            }
             $path = sprintf('data/wikidata/%s.json', $e);
 
             if (!file_exists($path)) {


### PR DESCRIPTION
I noticed cases where "name:etymology:wikidata" was not starting with Q number, so skip those