### PR TITLE
Add submodule Berlin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "cities/assen"]
 	path = cities/assen
 	url = https://github.com/RobinLinde/equalstreetnames-assen.git
+[submodule "cities/berlin"]
+	path = cities/berlin
+	url = https://github.com/gislars/equalstreetnames-berlin.git

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ See [`docs/README.md`](./docs/README.md)
 | 🇧🇪      | Brussels | https://equalstreetnames.brussels/    | [equalstreetnames-brussels](https://github.com/openknowledgebe/equalstreetnames-brussels) | [@jbelien](https://github.com/jbelien/) |
 | 🇷🇸      | Belgrade | https://naziviulica.openstreetmap.rs/ | [equalstreetnames-belgrade](https://github.com/stalker314314/equalstreetnames-belgrade)   | [@stalker314314](https://github.com/stalker314314/) |
 | 🇳🇱      | Assen | https://esn.rlin.eu/    | [equalstreetnames-assen](https://github.com/robinlinde/equalstreetnames-assen) | [@robinlinde](https://github.com/robinlinde/) |
+| 🇩🇪      | Berlin | --    | [equalstreetnames-berlin](https://github.com/gislars/equalstreetnames-berlin) | [@gislars](https://github.com/gislars/) |
 
 See [`docs/replicate.md`](./docs/replicate.md)
 
@@ -82,6 +83,12 @@ See [`docs/replicate.md`](./docs/replicate.md)
 
       ```
       npm run serve:assen
+      ```
+
+   1. For Berlin, run
+
+      ```
+      npm run serve:berlin
       ```
 
 1. Once installed and running, go to <http://localhost:1234/index.html>

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,5 @@
             "@statistics"
         ],
         "wikidata": "php scripts/wikidata.php"
-    },
-    "config": {
-        "process-timeout": 800
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
             "@statistics"
         ],
         "wikidata": "php scripts/wikidata.php"
+    },
+    "config": {
+        "process-timeout": 800
     }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "serve:belgrade": "parcel serve cities/belgrade/html/index.html cities/belgrade/html/*/index.html --global app --out-dir dist/belgrade",
     "serve:brugge": "parcel serve cities/brugge/html/index.html cities/brugge/html/*/index.html --global app --out-dir dist/brugge",
     "serve:brussels": "parcel serve cities/brussels/html/index.html cities/brussels/html/*/index.html --global app --out-dir dist/brussels",
+    "serve:berlin": "parcel serve cities/berlin/html/index.html cities/berlin/html/*/index.html --global app --out-dir dist/berlin",
     "serve:gent": "parcel serve cities/gent/html/index.html cities/gent/html/*/index.html --global app --out-dir dist/gent",
     "serve:leuven": "parcel serve cities/leuven/html/index.html cities/leuven/html/*/index.html --global app --out-dir dist/leuven"
   },
@@ -52,7 +53,7 @@
   "staticFiles": {
     "excludeGlob": "*.{csv,md}",
     "staticPath": [
-	  {
+      {
         "outDirPattern": "**/dist/assen",
         "staticPath": "cities/assen/data"
       },
@@ -67,6 +68,10 @@
       {
         "outDirPattern": "**/dist/brussels",
         "staticPath": "cities/brussels/data"
+      },
+      {
+        "outDirPattern": "**/dist/berlin",
+        "staticPath": "cities/berlin/data"
       },
       {
         "outDirPattern": "**/dist/gent",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:brussels": "parcel build cities/brussels/html/index.html cities/brussels/html/*/index.html --global app --out-dir dist/brussels --no-source-maps",
     "build:gent": "parcel build cities/gent/html/index.html cities/gent/html/*/index.html --global app --out-dir dist/gent --no-source-maps",
     "build:leuven": "parcel build cities/leuven/html/index.html cities/leuven/html/*/index.html --global app --out-dir dist/leuven --no-source-maps",
+    "build:berlin": "parcel build cities/berlin/html/index.html cities/berlin/html/*/index.html --global app --out-dir dist/berlin --no-source-maps",
     "serve:assen": "parcel serve cities/assen/html/index.html cities/assen/html/*/index.html --global app --out-dir dist/assen",
     "serve:belgrade": "parcel serve cities/belgrade/html/index.html cities/belgrade/html/*/index.html --global app --out-dir dist/belgrade",
     "serve:brugge": "parcel serve cities/brugge/html/index.html cities/brugge/html/*/index.html --global app --out-dir dist/brugge",

--- a/scripts/overpass-way.php
+++ b/scripts/overpass-way.php
@@ -43,8 +43,7 @@ function get(string $city): string
     $client = new \GuzzleHttp\Client();
     $response = $client->request(
         'GET',
-        sprintf('https://overpass-api.de/api/interpreter?data=%s', urlencode($query)),
-        ['timeout' => 400]
+        sprintf('https://overpass-api.de/api/interpreter?data=%s', urlencode($query))
     );
 
     $status = $response->getStatusCode();

--- a/scripts/overpass-way.php
+++ b/scripts/overpass-way.php
@@ -43,7 +43,8 @@ function get(string $city): string
     $client = new \GuzzleHttp\Client();
     $response = $client->request(
         'GET',
-        sprintf('https://overpass-api.de/api/interpreter?data=%s', urlencode($query))
+        sprintf('https://overpass-api.de/api/interpreter?data=%s', urlencode($query)),
+        ['timeout' => 400]
     );
 
     $status = $response->getStatusCode();


### PR DESCRIPTION
I just discovered this repository this week. So I gave it a try and made a submodule for Berlin. It was straight forward, thanks for your good work!
Since I run into timeouts I had to update composer.json and overpass-way.php. The docs for GuzzleHttp mentions when no timeout is given, it'll wait until it finishes. But after 60-80 seconds a exception got raised. Adding the timeout parameter solved this problem.

I tried to put the final map online, but first I have to figure out how. Since I don't want to put it at $webroot, instead at example.org/equalstreetnames-berlin, I have to figure out how it works with nginx or if I have to configure the build somehow.

On the other hand, Berlin only have few name:etymology:wikidata tags, not much to see yet. But I hope this map will change it.